### PR TITLE
Fix null delimiter quoting in flake check script

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -82,7 +82,7 @@
           echo "Required comment: $REQUIRED_COMMENT"
           
           # Find all flake.nix files in examples directory
-          while IFS= read -r -d ''' flake_file; do
+          while IFS= read -r -d '' flake_file; do
               checked_files=$((checked_files + 1))
               relative_path="''${flake_file#./}"
               


### PR DESCRIPTION
## Summary
- fix quoting in generated example linter script

## Testing
- `./lint-examples.sh`
- `bash check-examples.sh`


------
https://chatgpt.com/codex/tasks/task_e_68435e2477008333a1576677621c017e