### PR TITLE
Improve CLAUDE guidance

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,6 +12,12 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 - **Multi-language**: Support for Go, Dart, JavaScript/TypeScript, PHP, Swift, and more
 - **Developer-friendly**: Zero setup with comprehensive tooling included
 
+### Quick Start
+1. Install [Nix](https://nixos.org/download.html).
+2. Run `nix develop` to enter the development shell.
+3. Inside an example directory, run `nix run` to generate code.
+4. Browse the full documentation at <https://conneroisu.github.io/bufrnix/>.
+
 ## Key Commands
 
 ### Development and Building
@@ -413,3 +419,5 @@ config = {
 ```
 
 This project emphasizes **reproducibility**, **developer experience**, and **local-first development** while maintaining compatibility with the broader Protocol Buffers ecosystem.
+
+For full guides and examples visit <https://conneroisu.github.io/bufrnix/>.


### PR DESCRIPTION
## Summary
- add a Quick Start section to `CLAUDE.md`
- link to the hosted docs

## Testing
- `./check-examples.sh`
- `./test-examples.sh` *(fails: `nix command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_68436104548883338cb0fcc5c2feb366