### PR TITLE
Enable TypeScript strict mode

### DIFF
--- a/examples/ts-flake-parts/tsconfig.json
+++ b/examples/ts-flake-parts/tsconfig.json
@@ -6,7 +6,7 @@
     "moduleResolution": "node",
     "outDir": "./dist",
     "rootDir": ".",
-    "strict": false,
+    "strict": true,
     "esModuleInterop": true,
     "skipLibCheck": true,
     "forceConsistentCasingInFileNames": true,


### PR DESCRIPTION
## Summary
- enable TypeScript strict mode in the ts-flake-parts example

## Testing
- `./check-examples.sh`

------
https://chatgpt.com/codex/tasks/task_e_6843716004388333a57ccb63f23018dc