### PR TITLE
Add Python flake-parts example

### DIFF
--- a/examples/python-flake-parts/README.md
+++ b/examples/python-flake-parts/README.md
@@ -1,0 +1,18 @@
+# Python Flake-Parts Example
+
+This example demonstrates how to use [Bufrnix](https://github.com/conneroisu/bufrnix) with [flake-parts](https://flake.parts) to generate Python protobuf code with gRPC support.
+
+## Quick Start
+
+```bash
+# Navigate to the example
+cd examples/python-flake-parts
+
+# Generate the protobuf code
+nix build
+
+# Enter the development shell
+nix develop
+```
+
+The generated Python files will be placed in `proto/gen/python`.

--- a/examples/python-flake-parts/flake.lock
+++ b/examples/python-flake-parts/flake.lock
@@ -1,0 +1,127 @@
+{
+  "nodes": {
+    "bufrnix": {
+      "inputs": {
+        "nixpkgs": "nixpkgs",
+        "treefmt-nix": "treefmt-nix"
+      },
+      "locked": {
+        "path": "../..",
+        "type": "path"
+      },
+      "original": {
+        "path": "../..",
+        "type": "path"
+      },
+      "parent": []
+    },
+    "flake-parts": {
+      "inputs": {
+        "nixpkgs-lib": "nixpkgs-lib"
+      },
+      "locked": {
+        "lastModified": 1748821116,
+        "narHash": "sha256-F82+gS044J1APL0n4hH50GYdPRv/5JWm34oCJYmVKdE=",
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "rev": "49f0870db23e8c1ca0b5259734a02cd9e1e371a1",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1748929857,
+        "narHash": "sha256-lcZQ8RhsmhsK8u7LIFsJhsLh/pzR9yZ8yqpTzyGdj+Q=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "c2a03962b8e24e669fb37b7df10e7c79531ff1a4",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-lib": {
+      "locked": {
+        "lastModified": 1748740939,
+        "narHash": "sha256-rQaysilft1aVMwF14xIdGS3sj1yHlI6oKQNBRTF40cc=",
+        "owner": "nix-community",
+        "repo": "nixpkgs.lib",
+        "rev": "656a64127e9d791a334452c6b6606d17539476e2",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "nixpkgs.lib",
+        "type": "github"
+      }
+    },
+    "nixpkgs_2": {
+      "locked": {
+        "lastModified": 1747958103,
+        "narHash": "sha256-qmmFCrfBwSHoWw7cVK4Aj+fns+c54EBP8cGqp/yK410=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "fe51d34885f7b5e3e7b59572796e1bcb427eccb1",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_3": {
+      "locked": {
+        "lastModified": 1749143949,
+        "narHash": "sha256-QuUtALJpVrPnPeozlUG/y+oIMSLdptHxb3GK6cpSVhA=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "d3d2d80a2191a73d1e86456a751b83aa13085d7d",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "bufrnix": "bufrnix",
+        "flake-parts": "flake-parts",
+        "nixpkgs": "nixpkgs_3"
+      }
+    },
+    "treefmt-nix": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_2"
+      },
+      "locked": {
+        "lastModified": 1749194973,
+        "narHash": "sha256-eEy8cuS0mZ2j/r/FE0/LYBSBcIs/MKOIVakwHVuqTfk=",
+        "owner": "numtide",
+        "repo": "treefmt-nix",
+        "rev": "a05be418a1af1198ca0f63facb13c985db4cb3c5",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "treefmt-nix",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/examples/python-flake-parts/flake.nix
+++ b/examples/python-flake-parts/flake.nix
@@ -1,0 +1,46 @@
+{
+  description = "Python flake-parts example";
+
+  inputs = {
+    nixpkgs.url = "github:nixos/nixpkgs/nixos-unstable";
+    flake-parts.url = "github:hercules-ci/flake-parts";
+    # bufrnix.url = "github:conneroisu/bufrnix";
+    bufrnix.url = "path:../..";
+  };
+
+  outputs = inputs @ { self, nixpkgs, flake-parts, bufrnix, ... }:
+    flake-parts.lib.mkFlake { inherit inputs; } {
+      systems = [ "x86_64-linux" "aarch64-linux" "x86_64-darwin" "aarch64-darwin" ];
+
+      perSystem = { pkgs, ... }: {
+        packages.default = bufrnix.lib.mkBufrnixPackage {
+          inherit pkgs;
+          config = {
+            root = ./.;
+            protoc = {
+              includeDirectories = [ "proto" ];
+              files = [ "proto/greeter.proto" ];
+            };
+            languages.python = {
+              enable = true;
+              outputPath = "proto/gen/python";
+              grpc.enable = true;
+            };
+          };
+        };
+
+        devShells.default = pkgs.mkShell {
+          packages = with pkgs; [
+            python3
+            python3Packages.grpcio
+            python3Packages.protobuf
+            protobuf
+          ];
+          shellHook = ''
+            echo "Python flake-parts example"
+            echo "Run 'nix build' to generate code"
+          '';
+        };
+      };
+    };
+}

--- a/examples/python-flake-parts/proto/greeter.proto
+++ b/examples/python-flake-parts/proto/greeter.proto
@@ -1,0 +1,17 @@
+syntax = "proto3";
+
+package greeter;
+
+service Greeter {
+  rpc SayHello(HelloRequest) returns (HelloReply);
+  rpc SayHelloStream(HelloRequest) returns (stream HelloReply);
+}
+
+message HelloRequest {
+  string name = 1;
+}
+
+message HelloReply {
+  string message = 1;
+  int64 timestamp = 2;
+}

--- a/test-examples.sh
+++ b/test-examples.sh
@@ -264,6 +264,11 @@ test_example "js-protovalidate" \
 test_example "ts-flake-parts" \
     "gen/js/example/v1/user_pb.ts"
 
+# Test Python flake-parts example
+test_example "python-flake-parts" \
+    "proto/gen/python/greeter_pb2.py" \
+    "proto/gen/python/greeter_pb2_grpc.py"
+
 # TODO: Fix PHP features test (complex multi-config setup)
 # test_example "php-features-test" \
 #     "gen/php/basic/Test/V1/TestMessage.php"


### PR DESCRIPTION
## Summary
- add a new Python example that demonstrates flake-parts
- test the new example in the example test suite

## Testing
- `./lint-examples.sh`
- `nix build .#default` in `examples/python-flake-parts`
- `bufrnix` generation in `examples/python-flake-parts`

------
https://chatgpt.com/codex/tasks/task_e_68445b4116088333a8bf51c0e64b7388

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a Python example demonstrating automated protobuf and gRPC code generation using Nix flakes and flake-parts.
  - Added a gRPC service definition with example request and reply messages.
- **Documentation**
  - Added a README with setup instructions and usage details for the Python example.
- **Tests**
  - Included a new test to verify Python protobuf code generation in the example.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->